### PR TITLE
Avoid externalizing the child app

### DIFF
--- a/child/ember-cli-build.js
+++ b/child/ember-cli-build.js
@@ -31,6 +31,9 @@ module.exports = function (defaults) {
     // splitAtRoutes: ['route.name'], // can also be a RegExp
     packagerOptions: {
       webpackConfig: {
+        output:{
+          publicPath: 'http://localhost:4201/',
+        },
         plugins: [
           new ModuleFederationPlugin({
             name: 'child', // this name needs to match with the entry name

--- a/host/package.json
+++ b/host/package.json
@@ -68,5 +68,10 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@embroider/core@1.8.3": "patches/@embroider__core@1.8.3.patch"
+    }
   }
 }

--- a/host/patches/@embroider__core@1.8.3.patch
+++ b/host/patches/@embroider__core@1.8.3.patch
@@ -1,0 +1,16 @@
+diff --git a/src/babel-plugin-adjust-imports.js b/src/babel-plugin-adjust-imports.js
+index c056fade468947ac8e5ae1c65b35cc2224eb0d3f..eaf4a2f014010f0b6aebe610b7d782ad8d3a0b19 100644
+--- a/src/babel-plugin-adjust-imports.js
++++ b/src/babel-plugin-adjust-imports.js
+@@ -173,6 +173,11 @@ function handleExternal(specifier, sourceFile, opts, isDynamic) {
+             return specifier;
+         }
+     }
++
++    if (packageName === 'child') {
++      return specifier;
++    }
++
+     // absolute package imports can also be explicitly external based on their
+     // full specifier name
+     if (isExplicitlyExternal(specifier, pkg)) {

--- a/host/pnpm-lock.yaml
+++ b/host/pnpm-lock.yaml
@@ -1,5 +1,10 @@
 lockfileVersion: 5.4
 
+patchedDependencies:
+  '@embroider/core@1.8.3':
+    hash: vzb2v4gzchou2hm6f5ed2ridua
+    path: patches/@embroider__core@1.8.3.patch
+
 specifiers:
   '@ember/optional-features': ^2.0.0
   '@ember/test-helpers': ^2.8.1
@@ -45,7 +50,7 @@ devDependencies:
   '@ember/optional-features': 2.0.0
   '@ember/test-helpers': 2.8.1_bfwx5527ud67pz7vm5nr6nmdqq
   '@embroider/compat': 1.8.3_@embroider+core@1.8.3
-  '@embroider/core': 1.8.3
+  '@embroider/core': 1.8.3_vzb2v4gzchou2hm6f5ed2ridua
   '@embroider/webpack': 1.8.3_6ieuvvsbaka5ylmi63qvoovikm
   '@glimmer/component': 1.1.2_@babel+core@7.18.10
   '@glimmer/tracking': 1.1.2
@@ -2033,7 +2038,7 @@ packages:
       '@babel/core': 7.18.10_supports-color@8.1.1
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.18.10
       '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.18.10
-      '@embroider/core': 1.8.3_supports-color@8.1.1
+      '@embroider/core': 1.8.3_vzb2v4gzchou2hm6f5ed2ridua_supports-color@8.1.1
       babel-loader: 8.2.5_xc6oct4hcywdrbo4ned6ytbybm
     transitivePeerDependencies:
       - bufferutil
@@ -2055,7 +2060,7 @@ packages:
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.18.10
       '@babel/preset-env': 7.18.10_@babel+core@7.18.10
       '@babel/traverse': 7.18.11
-      '@embroider/core': 1.8.3
+      '@embroider/core': 1.8.3_vzb2v4gzchou2hm6f5ed2ridua
       '@embroider/macros': 1.8.3
       '@embroider/shared-internals': 1.8.3
       '@types/babel__code-frame': 7.0.3
@@ -2094,7 +2099,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@embroider/core/1.8.3:
+  /@embroider/core/1.8.3_vzb2v4gzchou2hm6f5ed2ridua:
     resolution: {integrity: sha512-/VdguyT/yhibgrjxL/J1ZFLvHo3EvUaBAxu9jAT3CYO9hIjWUKmJ81EZ0uK4zWykdifaefoz1/ctHnFjvm3/+w==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
@@ -2135,8 +2140,9 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
+    patched: true
 
-  /@embroider/core/1.8.3_supports-color@8.1.1:
+  /@embroider/core/1.8.3_vzb2v4gzchou2hm6f5ed2ridua_supports-color@8.1.1:
     resolution: {integrity: sha512-/VdguyT/yhibgrjxL/J1ZFLvHo3EvUaBAxu9jAT3CYO9hIjWUKmJ81EZ0uK4zWykdifaefoz1/ctHnFjvm3/+w==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
@@ -2177,6 +2183,7 @@ packages:
       - supports-color
       - utf-8-validate
     dev: true
+    patched: true
 
   /@embroider/hbs-loader/1.8.3_6ieuvvsbaka5ylmi63qvoovikm:
     resolution: {integrity: sha512-Lkl14BnOGHNeBJSbGbxdmakmyIzeHdGO7820gCBMTG+klC8F1JqJbr7p7DfNEc/ci/2E8UirDx3OlnYV/yWOXA==}
@@ -2185,7 +2192,7 @@ packages:
       '@embroider/core': 1.8.3
       webpack: ^5
     dependencies:
-      '@embroider/core': 1.8.3
+      '@embroider/core': 1.8.3_vzb2v4gzchou2hm6f5ed2ridua
       webpack: 5.74.0
     dev: true
 
@@ -2260,7 +2267,7 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.18.10
       '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.18.10
       '@embroider/babel-loader-8': 1.8.3_omufzdyusrmquceqjtzym5b3nu
-      '@embroider/core': 1.8.3
+      '@embroider/core': 1.8.3_vzb2v4gzchou2hm6f5ed2ridua
       '@embroider/hbs-loader': 1.8.3_6ieuvvsbaka5ylmi63qvoovikm
       '@embroider/shared-internals': 1.8.3
       '@types/source-map': 0.5.7


### PR DESCRIPTION
Embroider is able to interoperate with the large amount of imports in a typical ember app that do not really come from modules is by deferring reslution to runtime if build-time resolution does not work.

That means when embroider sees an import from the package `child` and no such package is listed in the package.json dependencies, it assumes it's dealing with runtime shenanigans and it shims the module with code that does `window.require('child/app')`, on the assumption that somebody somewhere is calling `window.define('child/app', ...)`.

This patch disables that behavior to get past the problem.

I also needed to set a publicPath on the child to get it loading its own assets.

The next failure revealed after these changes is that the child app is looking for its config meta tag and not finding it. That should hopefully be straightforward to fix by either creating a meta tag in the host app manually or by adjusting the child app to not use config-in-meta.